### PR TITLE
Option A: client on Vercel, server on Render

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,11 @@
   "type": "module",
   "license": "MIT",
   "scripts": {
-    "dev": "NODE_ENV=development tsx server/index.ts",
-    "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
-    "start": "NODE_ENV=production node dist/index.js",
+       "dev": "NODE_ENV=development tsx server/index.ts",
+    "build:client": "vite build",
+    "build:server": "esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist-server",
+    "build": "npm run build:client && npm run build:server",
+    "start": "NODE_ENV=production node dist-server/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push"
   },

--- a/server/app.ts
+++ b/server/app.ts
@@ -1,0 +1,18 @@
+import express from 'express';
+import cors from 'cors';
+
+const app = express();
+
+const allowed = [
+  'http://localhost:5173',
+  'https://<YOUR-VERCEL-PROJECT>.vercel.app'
+];
+
+app.use(cors({
+  origin: allowed,
+  credentials: true
+}));
+
+app.get('/api/health', (_, res) => res.json({ ok: true }));
+
+export default app;

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,0 +1,6 @@
+import app from './app.js';
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`API listening on ${port}`);
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  root: 'client',
+  plugins: [react()],
+  build: {
+    outDir: '../dist',
+    emptyOutDir: true
+  },
+  server: {
+    port: 5173
+  }
+});


### PR DESCRIPTION
This PR implements the Option A deployment configuration: the client is built on Vercel while the Express API runs on a separate Render/Railway service.

**Changes**
- Added `vite.config.ts` at the root to set Vite root to `client/` and output to `dist` for Vercel builds.
- Updated `package.json` scripts to add `build:client`, `build:server`, `build`, and `start` commands for separate client/server builds.
- Added `server/app.ts` that creates an Express app, enables CORS for local and Vercel origins, and exports the app.
- Added `server/index.ts` that imports the Express app and listens on `process.env.PORT`.

These changes allow the frontend to be deployed separately from the backend and support the recommended deployment strategy.